### PR TITLE
Fix for gcc and clang. Right now gcc throws an old ABI version of std…

### DIFF
--- a/test/ios_state_test.cpp
+++ b/test/ios_state_test.cpp
@@ -25,7 +25,7 @@
 #include <ostream>    // for std::endl, std::ostream
 #include <streambuf>  // for std::streambuf
 #include <string>     // for std::string
-#if defined(BOOST_GCC)
+#if defined(BOOST_GCC) || (defined(BOOST_CLANG) && defined(BOOST_GNU_STDLIB))
 #include <stdexcept>
 #endif
 

--- a/test/ios_state_test.cpp
+++ b/test/ios_state_test.cpp
@@ -10,6 +10,7 @@
 //   15 Jun 2003  Adjust to changes in Boost.Test (Daryle Walker)
 //   26 Feb 2002  Initial version (Daryle Walker)
 
+#include <boost/config.hpp>
 #include <boost/test/minimal.hpp>  // main, BOOST_CHECK, etc.
 
 #include <boost/cstdlib.hpp>       // for boost::exit_success
@@ -24,7 +25,9 @@
 #include <ostream>    // for std::endl, std::ostream
 #include <streambuf>  // for std::streambuf
 #include <string>     // for std::string
-
+#if defined(BOOST_GCC)
+#include <stdexcept>
+#endif
 
 // Facet with the bool names spelled backwards
 class backward_bool_names
@@ -181,11 +184,15 @@ saver_tests_1
         boost::io::ios_exception_saver const  ies( output );
         boost::io::ios_iostate_saver const    iis( output );
 
-        output.exceptions( ios_base::eofbit );
+        output.exceptions( ios_base::eofbit | ios_base::badbit );
         output.setstate( ios_base::eofbit );
         BOOST_ERROR( "previous line should have thrown" );
     }
+#if defined(BOOST_GCC) || (defined(BOOST_CLANG) && defined(BOOST_GNU_STDLIB))
+    catch ( std::exception &f )
+#else
     catch ( ios_base::failure &f )
+#endif
     {
         err << "Got the expected I/O failure: \"" << f.what() << "\".\n";
         BOOST_CHECK( output.exceptions() == ios_base::goodbit );
@@ -243,7 +250,11 @@ saver_tests_2
 
         BOOST_ERROR( "previous line should have thrown" );
     }
+#if defined(BOOST_GCC) || (defined(BOOST_CLANG) && defined(BOOST_GNU_STDLIB))
+    catch ( std::exception &f )
+#else
     catch ( ios_base::failure &f )
+#endif
     {
         err << "Got the expected I/O failure: \"" << f.what() << "\".\n";
         BOOST_CHECK( output.exceptions() == ios_base::goodbit );

--- a/test/ios_state_unit_test.cpp
+++ b/test/ios_state_unit_test.cpp
@@ -9,6 +9,7 @@
 //  Revision History
 //   12 Sep 2003  Initial version (Daryle Walker)
 
+#include <boost/config.hpp>
 #include <boost/io/ios_state.hpp>    // for boost::io::ios_flags_saver, etc.
 #include <boost/test/unit_test.hpp>  // for main, BOOST_CHECK, etc.
 
@@ -19,6 +20,9 @@
 #include <istream>   // for std::iostream
 #include <locale>    // for std::locale, std::numpunct
 #include <sstream>   // for std::stringstream, etc.
+#if defined(BOOST_GCC)
+#include <stdexcept>
+#endif
 
 
 // Global constants
@@ -226,9 +230,14 @@ ios_exception_saver_unit_test
 
         {
             boost::io::ios_iostate_saver  iis( ss );
+            ss.exceptions( ios_base::failbit | ios_base::badbit );
             char                          c;
 
+#if defined(BOOST_GCC) || (defined(BOOST_CLANG) && defined(BOOST_GNU_STDLIB))
+            BOOST_CHECK_THROW( ss >> c, std::exception );
+#else
             BOOST_CHECK_THROW( ss >> c, std::ios_base::failure );
+#endif
         }
     }
 
@@ -575,9 +584,14 @@ ios_all_saver_unit_test
 
         {
             boost::io::ios_iostate_saver  iis( ss );
+            ss.exceptions( ios_base::failbit | ios_base::badbit );
             char                          c;
 
+#if defined(BOOST_GCC) || (defined(BOOST_CLANG) && defined(BOOST_GNU_STDLIB))
+            BOOST_CHECK_THROW( ss >> c, std::exception );
+#else
             BOOST_CHECK_THROW( ss >> c, std::ios_base::failure );
+#endif
         }
 
         ss.tie( &clog );

--- a/test/ios_state_unit_test.cpp
+++ b/test/ios_state_unit_test.cpp
@@ -20,7 +20,7 @@
 #include <istream>   // for std::iostream
 #include <locale>    // for std::locale, std::numpunct
 #include <sstream>   // for std::stringstream, etc.
-#if defined(BOOST_GCC)
+#if defined(BOOST_GCC) || (defined(BOOST_CLANG) && defined(BOOST_GNU_STDLIB))
 #include <stdexcept>
 #endif
 


### PR DESCRIPTION
…::ios_base::failure even when the version being used is the newer ABI version of std::ios_base::failure. I have been told that this will be fixed in gcc-7.
