### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,18 @@ branches:
     - master
     - develop
 
+matrix:
+  include:
+    - os: linux
+      env: TEST_CMAKE=TRUE #Only for easier identification in travis web gui
+      install:
+        - git clone --depth 1 https://github.com/boostorg/config.git ../config
+
+      script:
+        - mkdir __build__ && cd __build__
+        - cmake ../test/test_cmake
+        - cmake --build .
+
 install:
   - cd ..
   - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,15 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5)
-project(BoostIO LANGUAGES CXX)
+cmake_minimum_required( VERSION 3.5 )
+project( BoostIO LANGUAGES CXX )
 
-add_library(boost_io INTERFACE)
-add_library(Boost::io ALIAS boost_io)
+add_library( boost_io INTERFACE )
+add_library( Boost::io ALIAS boost_io )
 
-target_include_directories(boost_io INTERFACE include)
+target_include_directories( boost_io INTERFACE include )
 
-target_link_libraries(boost_io
+target_link_libraries( boost_io
     INTERFACE
         Boost::config
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostIO LANGUAGES CXX)
+
+add_library(boost_io INTERFACE)
+add_library(Boost::io ALIAS boost_io)
+
+target_include_directories(boost_io INTERFACE include)
+
+target_link_libraries(boost_io
+    INTERFACE
+        Boost::config
+)

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -3,7 +3,8 @@
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 #
 # NOTE: This does NOT run the unit tests for Boost.IO.
-#       It only tests, if the CMakeLists.txt file in it's root works as expected
+#       It only tests, if the CMakeLists.txt file in the
+#       Boost.IO root directory works as expected.
 
 cmake_minimum_required( VERSION 3.5 )
 

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: This does NOT run the unit tests for Boost.IO.
+#       It only tests, if the CMakeLists.txt file in it's root works as expected
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( BoostIoCMakeSelfTest )
+
+add_subdirectory( ../../../config ${CMAKE_CURRENT_BINARY_DIR}/libs/config )
+add_subdirectory( ../.. ${CMAKE_CURRENT_BINARY_DIR}/libs/io )
+
+add_executable( boost_io_cmake_self_test main.cpp )
+target_link_libraries( boost_io_cmake_self_test Boost::io )

--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,0 +1,5 @@
+#include <boost/io/ios_state.hpp>
+#include <boost/io_fwd.hpp>
+
+int main() {
+}


### PR DESCRIPTION
Generate cmake target that can be used by other libraries
to express their dependency on this library and retrieve
any configuration information such as the include directory,
transitive dependencies, necessary compiler options or the
required c++ standards level.

For more information: https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M