### PR TITLE
Use `is_same` from Boost.TypeTraits

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,7 @@ install:
   - git submodule init libs/config
   - git submodule init libs/core
   - git submodule init libs/headers
+  - git submodule init libs/type_traits
   - git submodule init tools/build
   - git submodule init tools/boost_install
   - git submodule update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           git submodule init libs/config
           git submodule init libs/core
           git submodule init libs/headers
+          git submodule init libs/type_traits
           git submodule init tools/build
           git submodule init tools/boost_install
           git submodule update
@@ -170,6 +171,7 @@ jobs:
           git submodule init libs/config
           git submodule init libs/core
           git submodule init libs/static_assert
+          git submodule init libs/type_traits
           git submodule init libs/headers
           git submodule init tools/build
           git submodule init tools/boost_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -283,6 +283,7 @@ install:
   - git submodule init libs/config
   - git submodule init libs/core
   - git submodule init libs/headers
+  - git submodule init libs/type_traits
   - git submodule init tools/build
   - git submodule init tools/boost_install
   - git submodule update

--- a/test/ostream_joiner_test.cpp
+++ b/test/ostream_joiner_test.cpp
@@ -6,55 +6,55 @@ Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */
 #include <boost/io/ostream_joiner.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <sstream>
 
 void test_char_type()
 {
-    BOOST_TEST((boost::core::is_same<char,
+    BOOST_TEST((boost::is_same<char,
         boost::io::ostream_joiner<const char*>::char_type>::value));
 }
 
 void test_traits_type()
 {
-    BOOST_TEST((boost::core::is_same<std::char_traits<char>,
+    BOOST_TEST((boost::is_same<std::char_traits<char>,
         boost::io::ostream_joiner<const char*>::traits_type>::value));
 }
 
 void test_ostream_type()
 {
-    BOOST_TEST((boost::core::is_same<std::ostream,
+    BOOST_TEST((boost::is_same<std::ostream,
         boost::io::ostream_joiner<const char*>::ostream_type>::value));
 }
 
 void test_iterator_category()
 {
-    BOOST_TEST((boost::core::is_same<std::output_iterator_tag,
+    BOOST_TEST((boost::is_same<std::output_iterator_tag,
         boost::io::ostream_joiner<const char*>::iterator_category>::value));
 }
 
 void test_value_type()
 {
-    BOOST_TEST((boost::core::is_same<void,
+    BOOST_TEST((boost::is_same<void,
         boost::io::ostream_joiner<const char*>::value_type>::value));
 }
 
 void test_difference_type()
 {
-    BOOST_TEST((boost::core::is_same<void,
+    BOOST_TEST((boost::is_same<void,
         boost::io::ostream_joiner<const char*>::difference_type>::value));
 }
 
 void test_pointer()
 {
-    BOOST_TEST((boost::core::is_same<void,
+    BOOST_TEST((boost::is_same<void,
         boost::io::ostream_joiner<const char*>::pointer>::value));
 }
 
 void test_reference()
 {
-    BOOST_TEST((boost::core::is_same<void,
+    BOOST_TEST((boost::is_same<void,
         boost::io::ostream_joiner<const char*>::reference>::value));
 }
 


### PR DESCRIPTION
`boost::core::is_same` is deprecated, so use the one from Boost.TypeTraits.