### PR TITLE
Mark scope guard dtors as throwing when calling `basic_ios::exceptions()`

### DIFF
--- a/include/boost/io/ios_state.hpp
+++ b/include/boost/io/ios_state.hpp
@@ -155,7 +155,7 @@ public:
         s.exceptions(a);
     }
 
-    ~basic_ios_exception_saver() {
+    ~basic_ios_exception_saver() BOOST_NOEXCEPT_IF(false) {
         this->restore();
     }
 
@@ -413,7 +413,7 @@ public:
 #endif
         { }
 
-    ~basic_ios_all_saver() {
+    ~basic_ios_all_saver() BOOST_NOEXCEPT_IF(false) {
         this->restore();
     }
 


### PR DESCRIPTION
`basic_ios::exceptions()` may immediately throw an exception, if the stream has an error condition that matches the newly set exception mask. Since it is called in destructors of some scope guards, these destructors have to be explicitly marked as throwing to avoid terminating the process.