### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,6 @@ install:
   - git submodule init libs/config
   - git submodule init libs/core
   - git submodule init libs/headers
-  - git submodule init libs/static_assert
   - git submodule init libs/throw_exception
   - git submodule init libs/type_traits
   - git submodule init tools/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
           git submodule init libs/config
           git submodule init libs/core
           git submodule init libs/headers
-          git submodule init libs/static_assert
           git submodule init libs/throw_exception
           git submodule init libs/type_traits
           git submodule init tools/boost_install
@@ -201,7 +200,6 @@ jobs:
           git submodule init libs/config
           git submodule init libs/core
           git submodule init libs/headers
-          git submodule init libs/static_assert
           git submodule init libs/throw_exception
           git submodule init libs/type_traits
           git submodule init tools/boost_install


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.